### PR TITLE
Reference decorator

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -14,7 +14,7 @@
     "framework"
   ],
   "license": "MIT",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Light-weight framework designed to embrace core competencies",
   "private": false,
   "main": "./module.js",

--- a/src/core/decorators/module.ts
+++ b/src/core/decorators/module.ts
@@ -1,2 +1,3 @@
 export * from './state';
 export * from './storage';
+export * from './reference';

--- a/src/core/decorators/reference.ts
+++ b/src/core/decorators/reference.ts
@@ -1,7 +1,9 @@
 import { Guid } from 'tsbase/Functions/Guid';
 import { Component } from '../component';
 
-function definePropertyForReference(target: Component, key: string, id: string) {
+export function Reference(target: Component, key: string) {
+  const id = Guid.NewGuid();
+
   const element = () => document.getElementById(id) as HTMLElement;
 
   const getter = function () {
@@ -11,8 +13,4 @@ function definePropertyForReference(target: Component, key: string, id: string) 
   Object.defineProperty(target, key, {
     get: getter
   });
-}
-
-export function Reference(target: Component, key: string) {
-  definePropertyForReference(target, key, Guid.NewGuid());
 }

--- a/src/core/decorators/reference.ts
+++ b/src/core/decorators/reference.ts
@@ -3,8 +3,7 @@ import { Component } from '../component';
 
 export function Reference(target: Component, key: string) {
   const id = Guid.NewGuid();
-
-  const element = () => document.getElementById(id) as HTMLElement;
+  const element = () => document.querySelector(`[ref='${id}']`) as HTMLElement;
 
   const getter = function () {
     return element() || id;

--- a/src/core/decorators/reference.ts
+++ b/src/core/decorators/reference.ts
@@ -1,0 +1,18 @@
+import { Guid } from 'tsbase/Functions/Guid';
+import { Component } from '../component';
+
+function definePropertyForReference(target: Component, key: string, id: string) {
+  const element = () => document.getElementById(id) as HTMLElement;
+
+  const getter = function () {
+    return element() || id;
+  };
+
+  Object.defineProperty(target, key, {
+    get: getter
+  });
+}
+
+export function Reference(target: Component, key: string) {
+  definePropertyForReference(target, key, Guid.NewGuid());
+}

--- a/src/core/decorators/storage.ts
+++ b/src/core/decorators/storage.ts
@@ -3,7 +3,7 @@ import { Component } from '../component';
 
 const storageTypePostfix = '_storage_type';
 
-function definePropertyForStateInStore(target: Component, key: string, type: DomStorageMode) {
+function definePropertyForStorage(target: Component, key: string, type: DomStorageMode) {
   const storage = new DomStorageInterface(type);
 
   const getter = function () {
@@ -37,9 +37,9 @@ function definePropertyForStateInStore(target: Component, key: string, type: Dom
 }
 
 export function Session(target: Component, key: string) {
-  definePropertyForStateInStore(target, key, DomStorageMode.Session);
+  definePropertyForStorage(target, key, DomStorageMode.Session);
 }
 
 export function Local(target: Component, key: string) {
-  definePropertyForStateInStore(target, key, DomStorageMode.Local);
+  definePropertyForStorage(target, key, DomStorageMode.Local);
 }

--- a/src/core/decorators/tests/reference.spec.tsx
+++ b/src/core/decorators/tests/reference.spec.tsx
@@ -1,0 +1,50 @@
+import { Jsx, Fragment, JsxRenderer, ParseJsx } from '../../jsx';
+import { TestHelpers } from '../../../utilities/testHelpers';
+import { Component } from '../../component';
+import { Route } from '../../services/module';
+import { Reference } from '../reference';
+import { Strings } from 'tsbase/Functions/Strings';
+
+class TestComponent extends Component {
+  @Reference public ParagraphRef!: HTMLParagraphElement;
+  @Reference public InputRef!: HTMLInputElement;
+
+  public Template: (route?: Route) => Promise<Jsx> = async () => <>
+    <p id={this.ParagraphRef}>test</p>
+    <input id={this.InputRef} type="text"></input>
+  </>;
+}
+
+describe('Storage Decorators', () => {
+  let testComponent: TestComponent;
+
+  beforeEach(() => {
+    document.body.innerHTML = Strings.Empty;
+    testComponent = new TestComponent();
+  });
+
+  it('should return an id if no element has had it assigned', () => {
+    expect(typeof testComponent.ParagraphRef).toEqual('string');
+    expect(testComponent.ParagraphRef).toBeTruthy();
+  });
+
+  it('should hold a reference to an element in the template', async () => {
+    document.body.innerHTML = JsxRenderer.RenderJsx(<>{await testComponent.Render()}</>);
+
+    const paragraphHasInnerText = await TestHelpers.TimeLapsedCondition(() => {
+      return testComponent.ParagraphRef.innerHTML === 'test';
+    });
+    expect(paragraphHasInnerText).toBeTruthy();
+  });
+
+  it('should support the ability to get and set input values', async () => {
+    const value = 'test value';
+    document.body.innerHTML = JsxRenderer.RenderJsx(<>{await testComponent.Render()}</>);
+
+    const inputHasSetValue = await TestHelpers.TimeLapsedCondition(() => {
+      testComponent.InputRef.value = value;
+      return testComponent.InputRef.value === value;
+    });
+    expect(inputHasSetValue).toBeTruthy();
+  });
+});

--- a/src/core/decorators/tests/reference.spec.tsx
+++ b/src/core/decorators/tests/reference.spec.tsx
@@ -15,7 +15,7 @@ class TestComponent extends Component {
   </>;
 }
 
-describe('Storage Decorators', () => {
+describe('Reference Decorator', () => {
   let testComponent: TestComponent;
 
   beforeEach(() => {

--- a/src/core/decorators/tests/reference.spec.tsx
+++ b/src/core/decorators/tests/reference.spec.tsx
@@ -10,8 +10,8 @@ class TestComponent extends Component {
   @Reference public InputRef!: HTMLInputElement;
 
   public Template: (route?: Route) => Promise<Jsx> = async () => <>
-    <p id={this.ParagraphRef}>test</p>
-    <input id={this.InputRef} type="text"></input>
+    <p ref={this.ParagraphRef}>test</p>
+    <input ref={this.InputRef} type="text"></input>
   </>;
 }
 


### PR DESCRIPTION
Adds a decorator "@Reference" which allows a reference to be used to interact with a html element without having to get it by an id, and keep that id on hand.

Example of changeset this feature would allow:
<img width="1145" alt="Screen Shot 2021-09-22 at 1 41 28 PM" src="https://user-images.githubusercontent.com/12376716/134394234-9a561015-8e50-4b40-84fc-0e0b96abe6ca.png">
<img width="1234" alt="Screen Shot 2021-09-22 at 1 41 49 PM" src="https://user-images.githubusercontent.com/12376716/134394279-60710fe6-bb96-4113-a74a-31b723765f26.png">

^Instead of having to store a key to exchange for the a unique id, and the reference when setting an id or getting an element, you can reference the property and assign an id with it.

