### PR TITLE
Experiment: Page enhancement allowing head elements to be added for a given page and automatically removed when routing away

### DIFF
--- a/src/core/component.tsx
+++ b/src/core/component.tsx
@@ -49,7 +49,7 @@ export abstract class Component {
   ): Promise<string> {
     if (!this.Element) {
       Asap(() => {
-        if (this.Element?.parentElement) {
+        if (this.Element) {
           this.mutationObserver.observe(this.App.Main, {
             childList: true,
             subtree: true
@@ -134,7 +134,7 @@ export abstract class Component {
     });
   };
 
-  private disconnect: MutationCallback = () => {
+  private disconnect = () => {
     if (!this.Element) {
       this.mutationObserver.disconnect();
       this.headElements.forEach(e => e.remove());

--- a/src/core/component.tsx
+++ b/src/core/component.tsx
@@ -31,14 +31,7 @@ export abstract class Component {
   ) {
     this.Id = `fy-${Guid.NewGuid()}`;
     Component.IssuedIds.push(this.Id);
-
-    this.mutationObserver = new MutationObserver(() => {
-      if (!this.Element) {
-        this.mutationObserver.disconnect();
-        this.headElements.forEach(e => e.remove());
-        this.Disconnected();
-      }
-    });
+    this.mutationObserver = new MutationObserver(this.disconnect);
   }
 
   /**
@@ -133,5 +126,13 @@ export abstract class Component {
       this.headElements.push(newElement);
       this.windowDocument.head.appendChild(newElement);
     });
+  };
+
+  private disconnect = () => {
+    if (!this.Element) {
+      this.mutationObserver.disconnect();
+      this.headElements.forEach(e => e.remove());
+      this.Disconnected();
+    }
   };
 }

--- a/src/core/decorators/state.ts
+++ b/src/core/decorators/state.ts
@@ -14,7 +14,7 @@ function definePropertyForStateInStore(target: Component, key: string, storeType
 
     if (!component[subKey]) {
       const subId = store.ObservableAt(key).Subscribe(() => {
-        component.ReRender(component.App.Router.Route.CurrentIssue);
+        component.ReRender();
       });
       component[subKey] = subId;
     }

--- a/src/core/jsx.ts
+++ b/src/core/jsx.ts
@@ -1,10 +1,11 @@
 import { Guid } from 'tsbase/System/Guid';
 import { Strings } from 'tsbase/System/Strings';
 import { Command } from 'tsbase/Patterns/CommandQuery/Command';
+import { Router } from './services/router/router';
+import { Asap } from '../utilities/asap';
 import { Component } from './component';
 import { EventTypes } from './eventTypes';
 import { DomEvents } from './domEvents';
-import { Asap } from '../utilities/asap';
 
 export type Jsx = {
   attributes: Record<string, string>,
@@ -18,7 +19,7 @@ export function ParseJsx(nodeName, attributes, ...children): Promise<string> | J
   if (typeof nodeName === 'function' && nodeName.constructor) {
     const instance = new nodeName(attributes ?? undefined, children.length > 0 ? children : undefined) as Component;
     return new Promise(async (resolve) => {
-      const result = await instance.Render();
+      const result = await instance.Render(Router.Instance().Route.CurrentIssue);
       resolve(result);
     });
   }

--- a/src/core/page.ts
+++ b/src/core/page.ts
@@ -66,7 +66,7 @@ export abstract class Page extends Component {
   private async renderPageInMain(route: Route): Promise<void> {
     await this.App.UpdateLayout(this.Layout);
     this.seoService.SetDefaultTags(this.Title, this.Description, this.ImageUrl);
-    this.HeadElements.forEach(async e => {
+    this.HeadElements.forEach(e => {
       e.attributes['dynamic'] = 'true';
       const newElement = this.windowDocument.createElement(e.nodeName);
       for (const key in e.attributes) {

--- a/src/core/page.ts
+++ b/src/core/page.ts
@@ -24,8 +24,6 @@ export abstract class Page extends Component {
   protected Description: string = Strings.Empty;
   protected ImageUrl: string = Strings.Empty;
   protected Layout?: () => Promise<Jsx>;
-  private headElements: HTMLElement[] = [];
-  protected HeadElements: () => Promise<Omit<Jsx, 'children'>[]> = async () => [];
   private boundHref = Strings.Empty;
 
   constructor(
@@ -57,24 +55,15 @@ export abstract class Page extends Component {
       if (!this.Element || hrefIsNew) {
         await this.renderPageInMain(route as Route);
       }
-    } else if (this.App.Router.RouteHandled !== this.Id) {
+    } else {
       this.boundHref = Strings.Empty;
-      this.headElements.forEach(e => e.remove());
     }
   }
 
   private async renderPageInMain(route: Route): Promise<void> {
     await this.App.UpdateLayout(this.Layout);
     this.seoService.SetDefaultTags(this.Title, this.Description, this.ImageUrl);
-    (await this.HeadElements()).forEach(e => {
-      const newElement = this.windowDocument.createElement(e.nodeName);
-      for (const key in e.attributes) {
-        const value = e.attributes[key];
-        newElement.setAttribute(key, value);
-      }
-      this.headElements.push(newElement);
-      this.windowDocument.head.appendChild(newElement);
-    });
+
 
     const markup = await this.Render(route);
     this.App.Main.innerHTML = `${markup}\n${this.RenderMode}`;

--- a/src/core/page.ts
+++ b/src/core/page.ts
@@ -24,7 +24,8 @@ export abstract class Page extends Component {
   protected Description: string = Strings.Empty;
   protected ImageUrl: string = Strings.Empty;
   protected Layout?: () => Promise<Jsx>;
-  protected HeadElements?: () => Promise<Omit<Jsx, 'children'>[]>;
+  private headElements: HTMLElement[] = [];
+  protected HeadElements: () => Promise<Omit<Jsx, 'children'>[]> = async () => [];
   private boundHref = Strings.Empty;
 
   constructor(
@@ -58,21 +59,20 @@ export abstract class Page extends Component {
       }
     } else if (this.App.Router.RouteHandled !== this.Id) {
       this.boundHref = Strings.Empty;
-      Array.from(this.windowDocument.head.querySelectorAll('[dynamic=true]'))
-        .forEach(e => e.remove());
+      this.headElements.forEach(e => e.remove());
     }
   }
 
   private async renderPageInMain(route: Route): Promise<void> {
     await this.App.UpdateLayout(this.Layout);
     this.seoService.SetDefaultTags(this.Title, this.Description, this.ImageUrl);
-    (await this.HeadElements?.())?.forEach(e => {
-      e.attributes['dynamic'] = 'true';
+    (await this.HeadElements()).forEach(e => {
       const newElement = this.windowDocument.createElement(e.nodeName);
       for (const key in e.attributes) {
         const value = e.attributes[key];
         newElement.setAttribute(key, value);
       }
+      this.headElements.push(newElement);
       this.windowDocument.head.appendChild(newElement);
     });
 

--- a/src/core/page.ts
+++ b/src/core/page.ts
@@ -24,7 +24,7 @@ export abstract class Page extends Component {
   protected Description: string = Strings.Empty;
   protected ImageUrl: string = Strings.Empty;
   protected Layout?: () => Promise<Jsx>;
-  protected HeadElements: Omit<Jsx, 'children'>[] = [];
+  protected HeadElements?: () => Promise<Omit<Jsx, 'children'>[]>;
   private boundHref = Strings.Empty;
 
   constructor(
@@ -66,7 +66,7 @@ export abstract class Page extends Component {
   private async renderPageInMain(route: Route): Promise<void> {
     await this.App.UpdateLayout(this.Layout);
     this.seoService.SetDefaultTags(this.Title, this.Description, this.ImageUrl);
-    this.HeadElements.forEach(e => {
+    (await this.HeadElements?.())?.forEach(e => {
       e.attributes['dynamic'] = 'true';
       const newElement = this.windowDocument.createElement(e.nodeName);
       for (const key in e.attributes) {

--- a/src/core/page.ts
+++ b/src/core/page.ts
@@ -68,8 +68,12 @@ export abstract class Page extends Component {
     this.seoService.SetDefaultTags(this.Title, this.Description, this.ImageUrl);
     this.HeadElements.forEach(async e => {
       e.attributes['dynamic'] = 'true';
-      const newHtml = await JsxRenderer.RenderJsx(e);
-      this.windowDocument.head.innerHTML += newHtml;
+      const newElement = this.windowDocument.createElement(e.nodeName);
+      for (const key in e.attributes) {
+        const value = e.attributes[key];
+        newElement.setAttribute(key, value);
+      }
+      this.windowDocument.head.appendChild(newElement);
     });
 
     const markup = await this.Render(route);

--- a/src/core/page.ts
+++ b/src/core/page.ts
@@ -64,7 +64,6 @@ export abstract class Page extends Component {
     await this.App.UpdateLayout(this.Layout);
     this.seoService.SetDefaultTags(this.Title, this.Description, this.ImageUrl);
 
-
     const markup = await this.Render(route);
     this.App.Main.innerHTML = `${markup}\n${this.RenderMode}`;
     this.App.Router.UseClientRouting();

--- a/src/core/page.ts
+++ b/src/core/page.ts
@@ -24,7 +24,7 @@ export abstract class Page extends Component {
   protected Description: string = Strings.Empty;
   protected ImageUrl: string = Strings.Empty;
   protected Layout?: () => Promise<Jsx>;
-  protected HeadElements: Jsx[] = [];
+  protected HeadElements: Omit<Jsx, 'children'>[] = [];
   private boundHref = Strings.Empty;
 
   constructor(

--- a/src/core/page.ts
+++ b/src/core/page.ts
@@ -3,7 +3,7 @@ import { Route } from './services/router/route';
 import { App } from './app';
 import { Component } from './component';
 import { ISeoService, SeoService } from './services/module';
-import { Jsx, JsxRenderer } from './jsx';
+import { Jsx } from './jsx';
 
 export enum RenderModes {
   Dynamic = '<!-- fyord-dynamic-render -->',

--- a/src/core/tests/component.spec.tsx
+++ b/src/core/tests/component.spec.tsx
@@ -46,6 +46,8 @@ describe('Component', () => {
     mockComponentState.Setup(s => s.ObservableAt(Strings.Empty), fakeComponentStateObservable);
     mockComponentState.Setup(s => s.GetState(Strings.Empty), Strings.Empty);
     mockComponentState.Setup(s => s.SetState(Strings.Empty, Strings.Empty));
+    const fakeMain = document.createElement('main');
+    mockApp.Setup(a => a.Main, fakeMain);
 
     classUnderTest = new FakeComponent(mockDocument.Object, mockApp.Object);
     classUnderTest.SetState(mockComponentState.Object);
@@ -121,8 +123,9 @@ describe('Component', () => {
   });
 
   it('should observe mutations on parent element and call disconnected when element no longer exists in the dom', async () => {
-    classUnderTest = new FakeComponent();
-    document.body.innerHTML = await classUnderTest.Render();
+    classUnderTest = new FakeComponent(undefined, mockApp.Object);
+    mockApp.Object.Main.innerHTML = await classUnderTest.Render();
+    document.body.appendChild(mockApp.Object.Main);
 
     Asap(() => {
       classUnderTest.Element?.remove();
@@ -134,7 +137,7 @@ describe('Component', () => {
   });
 
   it('should observe mutations on parent element BUT NOT call disconnected when the component is still in the dom', async () => {
-    classUnderTest = new FakeComponent();
+    classUnderTest = new FakeComponent(undefined, mockApp.Object);
     document.body.innerHTML = await classUnderTest.Render();
 
     Asap(() => {

--- a/src/core/tests/page.spec.tsx
+++ b/src/core/tests/page.spec.tsx
@@ -121,10 +121,7 @@ describe('Page', () => {
     const mockElement = new Mock<HTMLElement>();
     mockElement.Setup(e => e.parentElement, fakeMain);
     mockDocument.SetupSequence([
-      [d => d.getElementById(id), null],
-      [d => d.getElementById(id), null],
-      [d => d.getElementById(id), mockElement.Object],
-      [d => d.getElementById(id), mockElement.Object]
+      [d => d.getElementById(id), null]
     ]);
     mockDocument.Setup(d => d.head, fakeHead);
     mockApp.Setup(a => a.Main, fakeMain);

--- a/src/core/tests/page.spec.tsx
+++ b/src/core/tests/page.spec.tsx
@@ -53,8 +53,10 @@ describe('Page', () => {
     mockApp.Setup(a => a.Router, mockRouter.Object);
     mockSeoService.Setup(s => s.SetDefaultTags());
     mockApp.Setup(a => a.UpdateLayout());
-
     mockRouter.Setup(r => r.UseClientRouting());
+    mockDocument.Setup(d => d.createElement('script'), document.createElement('script'));
+    mockDocument.Setup(d => d.createElement('style'), document.createElement('style'));
+
     classUnderTest = new FakePage(false, mockSeoService.Object, mockApp.Object, mockDocument.Object);
   });
 

--- a/src/core/tests/page.spec.tsx
+++ b/src/core/tests/page.spec.tsx
@@ -126,17 +126,9 @@ describe('Page', () => {
       () => fakeHead.innerHTML,
       m => m.toContain('<script src=\"fake\" dynamic=\"true\"></script><style link=\"fake\" dynamic=\"true\"></style>'));
 
-    fakeRouteObservable.Publish(fakeRoute);
-
-    mockRouter.Object.RouteHandled = '';
     classUnderTest.routeMatches = false;
-    fakeRouteObservable.Publish({
-      hashParams: [],
-      href: 'http://localhost',
-      path: '/fake',
-      queryParams: new Map<string, string>(),
-      routeParams: []
-    });
+    mockRouter.Object.RouteHandled = '';
+    fakeRouteObservable.Publish(fakeRoute);
 
     await TestHelpers.Expect(
       () => !fakeHead.innerHTML.includes('script') && fakeHead.innerHTML,

--- a/src/core/tests/page.spec.tsx
+++ b/src/core/tests/page.spec.tsx
@@ -12,7 +12,7 @@ const id = '12345';
 class FakePage extends Page {
   Template = async () => <div>test</div>;
   Route = async () => this.routeMatches;
-  HeadElements = [
+  HeadElements = async () => [
     <script src="fake" />,
     <style link="fake" />
   ];

--- a/src/core/tests/page.spec.tsx
+++ b/src/core/tests/page.spec.tsx
@@ -12,10 +12,6 @@ const id = '12345';
 class FakePage extends Page {
   Template = async () => <div>test</div>;
   Route = async () => this.routeMatches;
-  HeadElements = async () => [
-    <script src="fake" />,
-    <style link="fake" />
-  ];
 
   constructor(
     public routeMatches: boolean,
@@ -26,6 +22,13 @@ class FakePage extends Page {
     super(seoService, app, windowDocument);
     this.Id = id;
   }
+}
+
+class FakePageWithHeadElements extends FakePage {
+  HeadElements = async () => [
+    <script src="fake" />,
+    <style link="fake" />
+  ];
 }
 
 describe('Page', () => {
@@ -89,7 +92,7 @@ describe('Page', () => {
     const fakeMain = document.createElement('main');
     mockApp.Setup(a => a.Main, fakeMain);
     mockRouter.Setup(r => r.RouteHandled, Strings.Empty);
-    classUnderTest = new FakePage(true, mockSeoService.Object, mockApp.Object, mockDocument.Object);
+    classUnderTest = new FakePageWithHeadElements(true, mockSeoService.Object, mockApp.Object, mockDocument.Object);
 
     await fakeRouteObservable.Publish(fakeRoute);
 
@@ -104,10 +107,10 @@ describe('Page', () => {
 
     await TestHelpers.Expect(
       () => fakeHead.innerHTML,
-      m => m.toContain('<script src=\"fake\" dynamic=\"true\"></script><style link=\"fake\" dynamic=\"true\"></style>'));
+      m => m.toContain('<script src=\"fake\"></script><style link=\"fake\"></style>'));
   });
 
-  it('should remove dynamic head elements when routing away from page that rendered them', async () => {
+  it('should remove head elements when routing away from page that rendered them', async () => {
     fakeRoute.path = '/new-path';
     fakeRoute.href = 'http://localhost/new-path';
     const fakeHead = document.createElement('head');
@@ -118,13 +121,13 @@ describe('Page', () => {
     const fakeMain = document.createElement('main');
     mockApp.Setup(a => a.Main, fakeMain);
     mockRouter.Setup(r => r.RouteHandled, Strings.Empty);
-    classUnderTest = new FakePage(true, mockSeoService.Object, mockApp.Object, mockDocument.Object);
+    classUnderTest = new FakePageWithHeadElements(true, mockSeoService.Object, mockApp.Object, mockDocument.Object);
 
     await fakeRouteObservable.Publish(fakeRoute);
 
     await TestHelpers.Expect(
       () => fakeHead.innerHTML,
-      m => m.toContain('<script src=\"fake\" dynamic=\"true\"></script><style link=\"fake\" dynamic=\"true\"></style>'));
+      m => m.toContain('<script src=\"fake\"></script><style link=\"fake\"></style>'));
 
     classUnderTest.routeMatches = false;
     mockRouter.Object.RouteHandled = '';


### PR DESCRIPTION
### Background

Outside of updating title and meta tags, which are handled via the `SeoService` and `Page` properties, modifications to the head need to be handled via custom code.  This branch is an experiment if providing a `Page` level configuration option for declaring elements that should be rendered in the head for that page, but not retained after routing away from that page. 

### Use case
- You have a custom script, stylesheet, etc. that should or needs to be loaded only on certain routes.

### Implementation
- A new `Page` property has been added called, "HeaderElements"
- This new property is an array of Jsx - elements you want added to the head for that page
- Before appending them to the head on a positive route match, a new attribute (currently "dynamic") is added with a value of true 
- When the app routes to another page, it removes the elements added to the page by querying for that new attribute

### Example usage
- In addition to tests, see below snippets/screenshots from a working example

```typescript
export class NotFoundPage extends Page {
  Title = 'Not Found';

  RenderMode = RenderModes.Dynamic;
  Route = async () => true;
  HeadElements = [
    <script src="/hello.js" async="true" />
  ];
```

^ script from above "hello.js" executes, `alert('hello world');`

1. Initial load on homepage (no hello script)
<img width="795" alt="image" src="https://github.com/Fyord/fyord/assets/12376716/9f6ee82a-74ba-4127-a8b4-1bce5382a207">

2. After client or non-client routing to 404 page (script is added and executes)
<img width="775" alt="image" src="https://github.com/Fyord/fyord/assets/12376716/ea89730f-f95b-44b1-b2d7-dddb1bf4c185">

3. After client or non-client routing back to the home page
<img width="709" alt="image" src="https://github.com/Fyord/fyord/assets/12376716/43634d3b-fa4e-4f92-bf22-ca56f1566cbe">

